### PR TITLE
feat!: configのschemaをsiteごとに柔軟に設定できるように etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 FLAGS =
 GO = go
-BINARIES = planetctl picker hb
+BINARIES = planetctl picker
 BINDIR = dist
+REVISION = $(shell git rev-parse HEAD)
 SRC = $(shell find . -type f -name '*.go' -print)
 .PHONY: clean pre-build
 
@@ -11,6 +12,9 @@ pre-build:
 	mkdir -p ./$(BINDIR)
 	cp -r ./db ./$(BINDIR)/
 	cp -r ./template ./$(BINDIR)/
+
+hb: pre-build $(SRC)
+	$(GO) $(FLAGS) build -ldflags="-X main.GitRevision=$(REVISION)" -o ./$(BINDIR)/$@ ./cmd/$@/main.go
 
 $(BINARIES): pre-build $(SRC) 
 	$(GO) $(FLAGS) build -o ./$(BINDIR)/$@ ./cmd/$@/main.go

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REVISION = $(shell git rev-parse HEAD)
 SRC = $(shell find . -type f -name '*.go' -print)
 .PHONY: clean pre-build
 
-all: pre-build $(BINARIES)
+all: pre-build $(BINARIES) hb
 
 pre-build:
 	mkdir -p ./$(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ FLAGS =
 GO = go
 BINARIES = planetctl picker
 BINDIR = dist
-REVISION = $(shell git rev-parse HEAD)
+REVISION = $(shell git rev-parse --short=7 HEAD)
 SRC = $(shell find . -type f -name '*.go' -print)
 .PHONY: clean pre-build
 

--- a/cmd/hb/main.go
+++ b/cmd/hb/main.go
@@ -76,7 +76,7 @@ func main() {
 	for i := today; today.Sub(i).Abs().Hours() <= (time.Hour * 24 * 14).Hours(); i = i.Add(time.Hour * -24) {
 		dateStr := i.Format("2006-01-02")
 		res, err := db.Query(
-			`SELECT id, title, url, created_at, src
+			`SELECT id, content, url, created_at, src
 			 FROM posts
 			 WHERE date(created_at, "unixepoch", "localtime") = ?
 			 ORDER BY created_at DESC;`,

--- a/cmd/hb/main.go
+++ b/cmd/hb/main.go
@@ -19,30 +19,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-type Post struct {
-	Id         string
-	Content    string
-	Url        string
-	Date       int64
-	ParsedDate *time.Time
-	Src        string
-}
-
-type Site struct {
-	Url     string
-	IconUrl string
-	Title   string
-}
-
-type Meta struct {
-	Url         string
-	Description string
-	Title       string
-}
-
-type Config struct {
-	Meta Meta
-}
+var GitRevision = "unknown"
 
 func main() {
 	var configFilePath string
@@ -146,7 +123,7 @@ func main() {
 		"Sites":  sites,
 		"Config": hbConfig,
 		"Meta": hb.BinMeta{
-			Version: GIT_REVISION,
+			Version: GitRevision,
 		},
 	}
 	if err := tmpl.Execute(os.Stdout, data); err != nil {

--- a/cmd/hb/main.go
+++ b/cmd/hb/main.go
@@ -13,6 +13,8 @@ import (
 	_ "time/tzdata"
 
 	"github.com/eniehack/planet-someone/internal/config"
+	"github.com/eniehack/planet-someone/internal/hb"
+	"github.com/eniehack/planet-someone/internal/model"
 	"github.com/jmoiron/sqlx"
 	_ "modernc.org/sqlite"
 )
@@ -60,13 +62,13 @@ func main() {
 		slog.Error(fmt.Sprintf("cannot parse template: %s", err))
 		os.Exit(1)
 	}
-	hbConfig := new(Config)
-	hbConfig.Meta = Meta{
+	hbConfig := new(hb.Config)
+	hbConfig.Meta = hb.PageMeta{
 		Url:         c.Hb.Url,
 		Title:       c.Hb.Meta.Title,
 		Description: c.Hb.Meta.Description,
 	}
-	posts := make(map[string][]Post)
+	posts := make(map[string][]hb.Post)
 	tz, err := time.LoadLocation(c.Hb.TimeZone)
 	if err != nil {
 		slog.Error(fmt.Sprintf("cannot parse timezone: %s", err))
@@ -87,7 +89,7 @@ func main() {
 			os.Exit(1)
 		}
 		for res.Next() {
-			post := Post{}
+			post := hb.Post{}
 			if err := res.Scan(
 				&post.Id,
 				&post.Content,
@@ -108,12 +110,33 @@ func main() {
 		keys = append(keys, k)
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
-	sites := map[string]Site{}
+	sites := map[string]hb.Site{}
 	for _, site := range c.Picker.Sites {
-		sites[site.Id] = Site{
-			Url:     site.SiteUrl,
-			IconUrl: site.IconUrl,
-			Title:   site.Name,
+		switch site.Type {
+		case model.TYPE_MASTODON:
+			param, ok := site.RawParams.(*config.MastodonConfig)
+			if !ok {
+				return
+			}
+			sites[site.Id] = *param.GetMetadata()
+		case model.TYPE_MISSKEY:
+			param, ok := site.RawParams.(*config.MisskeyConfig)
+			if !ok {
+				return
+			}
+			sites[site.Id] = *param.GetMetadata()
+		case model.TYPE_BLOG:
+			param, ok := site.RawParams.(*config.BlogConfig)
+			if !ok {
+				return
+			}
+			sites[site.Id] = *param.GetMetadata()
+		case model.TYPE_SCRAPBOX:
+			param, ok := site.RawParams.(*config.ScrapboxConfig)
+			if !ok {
+				return
+			}
+			sites[site.Id] = *param.GetMetadata()
 		}
 	}
 
@@ -122,6 +145,9 @@ func main() {
 		"Posts":  posts,
 		"Sites":  sites,
 		"Config": hbConfig,
+		"Meta": hb.BinMeta{
+			Version: GIT_REVISION,
+		},
 	}
 	if err := tmpl.Execute(os.Stdout, data); err != nil {
 		slog.Error(fmt.Sprintf("failed to execute template: %s", err))

--- a/cmd/picker/main.go
+++ b/cmd/picker/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	defer db.Close()
 	for _, src := range c.Picker.Sites {
-		p, err := picker.PickerFactory(db, &src)
+		p, err := picker.PickerFactory(db, src.SiteConfig)
 		if err != nil {
 			slog.Error(fmt.Sprintf("cannot create picker on pickerfactory: %s", err))
 			os.Exit(1)

--- a/cmd/picker/main.go
+++ b/cmd/picker/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	defer db.Close()
 	for _, src := range c.Picker.Sites {
-		p, err := picker.PickerFactory(db, src.SiteConfig)
+		p, err := picker.PickerFactory(db, src)
 		if err != nil {
 			slog.Error(fmt.Sprintf("cannot create picker on pickerfactory: %s", err))
 			os.Exit(1)

--- a/cmd/planetctl/main.go
+++ b/cmd/planetctl/main.go
@@ -5,12 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
 	"time"
 
-	"github.com/antchfx/htmlquery"
 	"github.com/eniehack/planet-someone/internal/config"
 	"github.com/jmoiron/sqlx"
 	migrate "github.com/rubenv/sql-migrate"
@@ -22,15 +19,6 @@ import (
 const (
 	SQLITE = "sqlite"
 )
-
-func resolveAbsUrl(baseUrl *url.URL, path string) (*url.URL, error) {
-	relUrl, err := url.Parse(path)
-	if err != nil {
-		return nil, err
-	}
-	abs := baseUrl.ResolveReference(relUrl)
-	return abs, nil
-}
 
 func initAction(ctx context.Context, cmd *cli.Command) error {
 	c := config.ReadConfig(cmd.String("config"))
@@ -52,52 +40,17 @@ func initAction(ctx context.Context, cmd *cli.Command) error {
 
 func validateConfig(ctx context.Context, cmd *cli.Command) error {
 	c := config.ReadConfig(cmd.String("config"))
-	newSites := []config.SiteConfig{}
+	newSites := []config.SiteConfigWrapper{}
 	for _, siteConfig := range c.Picker.Sites {
 		if len(siteConfig.Id) == 0 {
 			return errors.New("id is required")
 		}
-		if len(siteConfig.SiteUrl) == 0 {
-			return fmt.Errorf("%s: site_url is undefined", siteConfig.Id)
-		}
-		client := new(http.Client)
-		reqUrl, err := url.Parse(siteConfig.SiteUrl)
+		params, err := config.GetParam(siteConfig)
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl.String(), nil)
-		if err != nil {
+		if err := params.CompleteMetadata(ctx, siteConfig.Id); err != nil {
 			return err
-		}
-		req.Header.Set("User-Agent", config.UserAgent)
-		resp, err := client.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		doc, err := htmlquery.Parse(resp.Body)
-		if err != nil {
-			return err
-		}
-		if len(siteConfig.Name) == 0 {
-			titleElem := htmlquery.FindOne(doc, `//title/text()`)
-			siteConfig.Name = htmlquery.InnerText(titleElem)
-		}
-		if len(siteConfig.SourceUrl) == 0 {
-			feedUrlElem := htmlquery.FindOne(doc, `//link[@rel="alternate" and (@type="application/rss+xml" or @type="application/atom+xml")]/@href`)
-			srcUrl, err := resolveAbsUrl(reqUrl, htmlquery.InnerText(feedUrlElem))
-			if err != nil {
-				return err
-			}
-			siteConfig.SourceUrl = srcUrl.String()
-		}
-		if len(siteConfig.IconUrl) == 0 {
-			iconUrlElem := htmlquery.FindOne(doc, `//link[@rel="icon"]/@href`)
-			iconUrl, err := resolveAbsUrl(reqUrl, htmlquery.InnerText(iconUrlElem))
-			if err != nil {
-				return err
-			}
-			siteConfig.IconUrl = iconUrl.String()
 		}
 		time.Sleep(time.Second * 1)
 		newSites = append(newSites, siteConfig)

--- a/cmd/planetctl/main.go
+++ b/cmd/planetctl/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/eniehack/planet-someone/internal/config"
+	"github.com/eniehack/planet-someone/internal/model"
 	"github.com/jmoiron/sqlx"
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/urfave/cli/v3"
@@ -73,9 +74,39 @@ func addSite(ctx context.Context, cmd *cli.Command) error {
 		return errors.New("must be 1 argument")
 	}
 	c := config.ReadConfig(cmd.String("config"))
-	c.Picker.Sites = append(c.Picker.Sites, config.SiteConfig{
-		Id: cmd.Args().First(),
-	})
+	var scw *config.SiteConfigWrapper
+	switch cmd.String("type") {
+	case model.TYPE_MASTODON:
+		scw = &config.SiteConfigWrapper{
+			Type:      cmd.String("type"),
+			Id:        cmd.Args().First(),
+			RawParams: &config.MastodonConfig{},
+		}
+	case model.TYPE_MISSKEY:
+		scw = &config.SiteConfigWrapper{
+			Type:      cmd.String("type"),
+			Id:        cmd.Args().First(),
+			RawParams: &config.MisskeyConfig{},
+		}
+	case model.TYPE_SCRAPBOX:
+		scw = &config.SiteConfigWrapper{
+			Type:      cmd.String("type"),
+			Id:        cmd.Args().First(),
+			RawParams: &config.ScrapboxConfig{},
+		}
+	case model.TYPE_BLOG:
+		scw = &config.SiteConfigWrapper{
+			Type:      cmd.String("type"),
+			Id:        cmd.Args().First(),
+			RawParams: &config.BlogConfig{},
+		}
+	default:
+		return errors.New("unexpected site type")
+	}
+	c.Picker.Sites = append(c.Picker.Sites, *scw)
+	fmt.Printf("SiteConfigWrapper: %+v\n", scw)
+	fmt.Printf("SiteConfigWrapper Type: %T\n", scw.RawParams)
+
 	f, err := os.OpenFile(cmd.String("config"), os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
@@ -128,6 +159,11 @@ func main() {
 							&cli.StringFlag{
 								Name:    "config",
 								Aliases: []string{"c"},
+							},
+							&cli.StringFlag{
+								Name:     "type",
+								Aliases:  []string{"t"},
+								Required: true,
 							},
 						},
 						Action: addSite,

--- a/config.example.yml
+++ b/config.example.yml
@@ -9,10 +9,11 @@ hb:
     title: "planet eniehack"
     description: ""
 picker:
-    sites:
-        - id: scrapbox
-          source_url: 
-          site_url: https://scrapbox.io/eniehack/
-          name: 
-          type: scrapbox
-          icon_url: 
+  sites:
+    - id: scrapbox
+      type: scrapbox
+      params:
+        source_url: 
+        site_url: https://scrapbox.io/eniehack/
+        name: 
+        icon_url: 

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -2,10 +2,11 @@
 PRAGMA foreign_keys=true;
 
 CREATE TABLE posts (
-    id text,
-    title text NOT NULL,
+    id text NOt NULL UNIQUE,
+    content text NOT NULL,
     url text NOT NULL, 
     src text NOT NULL,
+    type text NOT NULL,
     created_at integer NOT NULL,
     PRIMARY KEY (created_at, url)
 );

--- a/internal/config/blog.go
+++ b/internal/config/blog.go
@@ -1,0 +1,14 @@
+package config
+
+type BlogConfig struct {
+	Type      string `yaml:"type"`
+	Id        string `yaml:"id"`
+	SourceUrl string `yaml:"source_url"`
+	SiteUrl   string `yaml:"site_url"`
+	Name      string `yaml:"name"`
+	IconUrl   string `yaml:"icon_url"`
+}
+
+func (c *BlogConfig) GetType() string {
+	return c.Type
+}

--- a/internal/config/blog.go
+++ b/internal/config/blog.go
@@ -1,14 +1,78 @@
 package config
 
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antchfx/htmlquery"
+	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
+)
+
 type BlogConfig struct {
-	Type      string `yaml:"type"`
-	Id        string `yaml:"id"`
+	Id        string
+	Type      string
 	SourceUrl string `yaml:"source_url"`
 	SiteUrl   string `yaml:"site_url"`
 	Name      string `yaml:"name"`
 	IconUrl   string `yaml:"icon_url"`
 }
 
+func (c *BlogConfig) SetId(id string) {
+	c.Id = id
+}
+
+func (c *BlogConfig) SetType(typ string) {
+	c.Type = typ
+}
+
 func (c *BlogConfig) GetType() string {
 	return c.Type
+}
+
+func (c *BlogConfig) CompleteMetadata(ctx context.Context, id string) error {
+	if len(c.SiteUrl) == 0 {
+		return fmt.Errorf("%s: site_url is undefined", id)
+	}
+	client := new(http.Client)
+	reqUrl, err := url.Parse(c.SiteUrl)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	doc, err := htmlquery.Parse(resp.Body)
+	if err != nil {
+		return err
+	}
+	if len(c.Name) == 0 {
+		titleElem := htmlquery.FindOne(doc, `//title/text()`)
+		c.Name = htmlquery.InnerText(titleElem)
+	}
+	if len(c.SourceUrl) == 0 {
+		feedUrlElem := htmlquery.FindOne(doc, `//link[@rel="alternate" and (@type="application/rss+xml" or @type="application/atom+xml")]/@href`)
+		srcUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(feedUrlElem))
+		if err != nil {
+			return err
+		}
+		c.SourceUrl = srcUrl.String()
+	}
+	if len(c.IconUrl) == 0 {
+		iconUrlElem := htmlquery.FindOne(doc, `//link[@rel="icon"]/@href`)
+		iconUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(iconUrlElem))
+		if err != nil {
+			return err
+		}
+		c.IconUrl = iconUrl.String()
+	}
+	return nil
 }

--- a/internal/config/blog.go
+++ b/internal/config/blog.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/antchfx/htmlquery"
+	"github.com/eniehack/planet-someone/internal/hb"
 	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
 )
 
@@ -75,4 +76,12 @@ func (c *BlogConfig) CompleteMetadata(ctx context.Context, id string) error {
 		c.IconUrl = iconUrl.String()
 	}
 	return nil
+}
+
+func (c *BlogConfig) GetMetadata() *hb.Site {
+	return &hb.Site{
+		Url:     c.SiteUrl,
+		IconUrl: c.IconUrl,
+		Title:   c.Name,
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 
+	"github.com/eniehack/planet-someone/internal/hb"
 	"github.com/eniehack/planet-someone/internal/model"
 	"gopkg.in/yaml.v3"
 )
@@ -197,6 +198,7 @@ type SiteConfig interface {
 	SetType(typ string)
 	GetType() string
 	CompleteMetadata(ctx context.Context, id string) error
+	GetMetadata() *hb.Site
 }
 
 type SiteConfigWrapper struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"reflect"
 
 	"github.com/eniehack/planet-someone/internal/model"
 	"gopkg.in/yaml.v3"
@@ -35,54 +39,135 @@ func ReadConfig(configFilePath string) *Config {
 	return c
 }
 
-func NewSiteConfig(typ string) (SiteConfig, error) {
-	var c SiteConfig
-	switch typ {
-	case model.TYPE_MASTODON:
-		c = new(MastodonConfig)
-	case model.TYPE_MISSKEY:
-		c = new(MisskeyConfig)
-	case model.TYPE_SCRAPBOX:
-		c = new(ScrapboxConfig)
-	case model.TYPE_BLOG:
-		c = new(BlogConfig)
-	default:
-		return nil, fmt.Errorf("unknown type: %s", typ)
-	}
-	return c, nil
-}
-
 func (sw *SiteConfigWrapper) UnmarshalYAML(value *yaml.Node) error {
 	type rawWrapper struct {
-		Type string `yaml:"type"`
+		Type   string      `yaml:"type"`
+		Id     string      `yaml:"id"`
+		Params interface{} `yaml:"params"` // paramsはtypeによって形が異なるので、一旦interface{}としてDecodeし、paramsだけ再度encodeすることで狙ったstructに変換できる
 	}
-	var raw rawWrapper
+	raw := new(rawWrapper)
 	if err := value.Decode(&raw); err != nil {
 		return err
 	}
 	sw.Type = raw.Type
+	sw.Id = raw.Id
 
-	// 型に応じて具体的な構造体を割り当てる
-	var cfg SiteConfig
+	buf := new(bytes.Buffer)
+	if err := yaml.NewEncoder(buf).Encode(raw.Params); err != nil {
+		return err
+	}
+
 	switch raw.Type {
 	case model.TYPE_MASTODON:
-		cfg = new(MastodonConfig)
+		cfg := new(MastodonConfig)
+		if err := yaml.NewDecoder(buf).Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode mastodon params: %w", err)
+		}
+		sw.RawParams = cfg
 	case model.TYPE_MISSKEY:
-		cfg = new(MisskeyConfig)
+		cfg := new(MisskeyConfig)
+		if err := yaml.NewDecoder(buf).Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode misskey params: %w", err)
+		}
+		sw.RawParams = cfg
 	case model.TYPE_SCRAPBOX:
-		cfg = new(ScrapboxConfig)
+		cfg := new(ScrapboxConfig)
+		if err := yaml.NewDecoder(buf).Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode scrapbox params: %w", err)
+		}
+		fmt.Printf("decoded params: %+v\n", cfg)
+		sw.RawParams = cfg
 	case model.TYPE_BLOG:
-		cfg = new(BlogConfig)
+		cfg := new(BlogConfig)
+		if err := yaml.NewDecoder(buf).Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode blog params: %w", err)
+		}
+		sw.RawParams = cfg
 	default:
 		return fmt.Errorf("unknown type: %s", raw.Type)
 	}
 
-	// 構造体にデコード
-	if err := value.Decode(cfg); err != nil {
-		return err
-	}
-	sw.SiteConfig = cfg
 	return nil
+}
+
+func (sw *SiteConfigWrapper) MarshalYAML() (interface{}, error) {
+	fmt.Printf("SiteConfig Type: %T, Value: %+v\n", sw.RawParams, sw.RawParams)
+
+	if sw.RawParams == nil {
+		fmt.Println("SiteConfig is nil")
+		return nil, fmt.Errorf("SiteConfig is nil")
+	}
+	result := map[string]interface{}{
+		"type": sw.Type,
+		"id":   sw.Id,
+	}
+
+	params := map[string]interface{}{}
+	v := reflect.ValueOf(sw.RawParams)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("yaml")
+		fmt.Println(tag)
+		if len(tag) == 0 || tag == "-" {
+			continue
+		}
+		params[tag] = v.Field(i).Interface()
+		fmt.Println(tag, v.Field(i).Interface())
+	}
+	fmt.Println(params)
+	result["params"] = params
+	return result, nil
+}
+
+func GetParams[T any](s SiteConfigWrapper) (*T, bool) {
+	if params, ok := s.RawParams.(T); ok {
+		return &params, true
+	}
+	if params, ok := s.RawParams.(*T); ok {
+		return params, true
+	}
+	return nil, false
+}
+
+func GetParam(s SiteConfigWrapper) (SiteConfig, error) {
+	var (
+		params SiteConfig
+		ok     bool
+	)
+	switch s.Type {
+	case model.TYPE_MASTODON:
+		params, ok = GetParams[MastodonConfig](s)
+		if !ok {
+			return nil, errors.New("cannot fetch MastodonConfig")
+		}
+	case model.TYPE_MISSKEY:
+		params, ok = GetParams[MisskeyConfig](s)
+		if !ok {
+			return nil, errors.New("cannot fetch MisskeyConfig")
+		}
+	case model.TYPE_SCRAPBOX:
+		var ok bool
+		params, ok = GetParams[ScrapboxConfig](s)
+		if !ok {
+			return nil, errors.New("cannot fetch ScrapboxConfig")
+		}
+	case model.TYPE_BLOG:
+		var ok bool
+		params, ok = GetParams[BlogConfig](s)
+		if !ok {
+			return nil, errors.New("cannot fetch BlogConfig")
+		}
+	default:
+		return nil, fmt.Errorf("unexpected site type: %s", s.Type)
+	}
+	params.SetId(s.Id)
+	params.SetType(s.Type)
+	fmt.Printf("params: %+v", params)
+	return params, nil
 }
 
 type Config struct {
@@ -108,13 +193,16 @@ type PickerConfig struct {
 }
 
 type SiteConfig interface {
+	SetId(id string)
+	SetType(typ string)
 	GetType() string
+	CompleteMetadata(ctx context.Context, id string) error
 }
 
 type SiteConfigWrapper struct {
-	Type       string                 `yaml:"type"`
-	SiteConfig SiteConfig             `yaml:"-"`
-	RawConfig  map[string]interface{} `yaml:",inline"`
+	Type      string      `yaml:"type"`
+	Id        string      `yaml:"id"`
+	RawParams interface{} `yaml:"params"`
 }
 
 type OgpConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
 
+	"github.com/eniehack/planet-someone/internal/model"
 	"gopkg.in/yaml.v3"
 )
 
@@ -33,6 +35,56 @@ func ReadConfig(configFilePath string) *Config {
 	return c
 }
 
+func NewSiteConfig(typ string) (SiteConfig, error) {
+	var c SiteConfig
+	switch typ {
+	case model.TYPE_MASTODON:
+		c = new(MastodonConfig)
+	case model.TYPE_MISSKEY:
+		c = new(MisskeyConfig)
+	case model.TYPE_SCRAPBOX:
+		c = new(ScrapboxConfig)
+	case model.TYPE_BLOG:
+		c = new(BlogConfig)
+	default:
+		return nil, fmt.Errorf("unknown type: %s", typ)
+	}
+	return c, nil
+}
+
+func (sw *SiteConfigWrapper) UnmarshalYAML(value *yaml.Node) error {
+	type rawWrapper struct {
+		Type string `yaml:"type"`
+	}
+	var raw rawWrapper
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	sw.Type = raw.Type
+
+	// 型に応じて具体的な構造体を割り当てる
+	var cfg SiteConfig
+	switch raw.Type {
+	case model.TYPE_MASTODON:
+		cfg = new(MastodonConfig)
+	case model.TYPE_MISSKEY:
+		cfg = new(MisskeyConfig)
+	case model.TYPE_SCRAPBOX:
+		cfg = new(ScrapboxConfig)
+	case model.TYPE_BLOG:
+		cfg = new(BlogConfig)
+	default:
+		return fmt.Errorf("unknown type: %s", raw.Type)
+	}
+
+	// 構造体にデコード
+	if err := value.Decode(cfg); err != nil {
+		return err
+	}
+	sw.SiteConfig = cfg
+	return nil
+}
+
 type Config struct {
 	DB     DbConfig     `yaml:"db"`
 	Picker PickerConfig `yaml:"picker"`
@@ -52,16 +104,17 @@ type DbConfig struct {
 }
 
 type PickerConfig struct {
-	Sites []SiteConfig `yaml:"sites"`
+	Sites []SiteConfigWrapper `yaml:"sites"`
 }
 
-type SiteConfig struct {
-	Id        string `yaml:"id"`
-	SourceUrl string `yaml:"source_url"`
-	SiteUrl   string `yaml:"site_url"`
-	Name      string `yaml:"name"`
-	Type      string `yaml:"type"`
-	IconUrl   string `yaml:"icon_url"`
+type SiteConfig interface {
+	GetType() string
+}
+
+type SiteConfigWrapper struct {
+	Type       string                 `yaml:"type"`
+	SiteConfig SiteConfig             `yaml:"-"`
+	RawConfig  map[string]interface{} `yaml:",inline"`
 }
 
 type OgpConfig struct {

--- a/internal/config/mastodon.go
+++ b/internal/config/mastodon.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/antchfx/htmlquery"
+	"github.com/eniehack/planet-someone/internal/hb"
 	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
 )
 
@@ -29,6 +30,14 @@ func (c *MastodonConfig) SetType(typ string) {
 
 func (c *MastodonConfig) GetType() string {
 	return c.Type
+}
+
+func (c *MastodonConfig) GetMetadata() *hb.Site {
+	return &hb.Site{
+		Url:     c.SiteUrl,
+		IconUrl: c.IconUrl,
+		Title:   c.Name,
+	}
 }
 
 func (c *MastodonConfig) CompleteMetadata(ctx context.Context, id string) error {

--- a/internal/config/mastodon.go
+++ b/internal/config/mastodon.go
@@ -1,0 +1,14 @@
+package config
+
+type MastodonConfig struct {
+	Type      string `yaml:"type"`
+	Id        string `yaml:"id"`
+	SourceUrl string `yaml:"source_url"`
+	SiteUrl   string `yaml:"site_url"`
+	Name      string `yaml:"name"`
+	IconUrl   string `yaml:"icon_url"`
+}
+
+func (c *MastodonConfig) GetType() string {
+	return c.Type
+}

--- a/internal/config/mastodon.go
+++ b/internal/config/mastodon.go
@@ -15,8 +15,8 @@ type MastodonConfig struct {
 	Type      string
 	SourceUrl string `yaml:"source_url"`
 	SiteUrl   string `yaml:"site_url"`
-	Name      string `yaml:"name,omitempty"`
-	IconUrl   string `yaml:"icon_url,omitempty"`
+	Name      string `yaml:"name"`
+	IconUrl   string `yaml:"icon_url"`
 }
 
 func (c *MastodonConfig) SetId(id string) {

--- a/internal/config/mastodon.go
+++ b/internal/config/mastodon.go
@@ -1,14 +1,78 @@
 package config
 
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antchfx/htmlquery"
+	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
+)
+
 type MastodonConfig struct {
-	Type      string `yaml:"type"`
-	Id        string `yaml:"id"`
+	Id        string
+	Type      string
 	SourceUrl string `yaml:"source_url"`
 	SiteUrl   string `yaml:"site_url"`
-	Name      string `yaml:"name"`
-	IconUrl   string `yaml:"icon_url"`
+	Name      string `yaml:"name,omitempty"`
+	IconUrl   string `yaml:"icon_url,omitempty"`
+}
+
+func (c *MastodonConfig) SetId(id string) {
+	c.Id = id
+}
+
+func (c *MastodonConfig) SetType(typ string) {
+	c.Type = typ
 }
 
 func (c *MastodonConfig) GetType() string {
 	return c.Type
+}
+
+func (c *MastodonConfig) CompleteMetadata(ctx context.Context, id string) error {
+	if len(c.SiteUrl) == 0 {
+		return fmt.Errorf("%s: site_url is undefined", id)
+	}
+	client := new(http.Client)
+	reqUrl, err := url.Parse(c.SiteUrl)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	doc, err := htmlquery.Parse(resp.Body)
+	if err != nil {
+		return err
+	}
+	if len(c.Name) == 0 {
+		titleElem := htmlquery.FindOne(doc, `//title/text()`)
+		c.Name = htmlquery.InnerText(titleElem)
+	}
+	if len(c.SourceUrl) == 0 {
+		feedUrlElem := htmlquery.FindOne(doc, `//link[@rel="alternate" and (@type="application/rss+xml" or @type="application/atom+xml")]/@href`)
+		srcUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(feedUrlElem))
+		if err != nil {
+			return err
+		}
+		c.SourceUrl = srcUrl.String()
+	}
+	if len(c.IconUrl) == 0 {
+		iconUrlElem := htmlquery.FindOne(doc, `//link[@rel="icon"]/@href`)
+		iconUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(iconUrlElem))
+		if err != nil {
+			return err
+		}
+		c.IconUrl = iconUrl.String()
+	}
+	return nil
 }

--- a/internal/config/misskey.go
+++ b/internal/config/misskey.go
@@ -1,0 +1,16 @@
+package config
+
+type MisskeyConfig struct {
+	Type        string `yaml:"type"`
+	Id          string `yaml:"id"`
+	InstanceUrl string `yaml:"instance_url"`
+	UserId      string `yaml:"user_id"`
+	SourceUrl   string `yaml:"source_url"`
+	SiteUrl     string `yaml:"site_url"`
+	Name        string `yaml:"name"`
+	IconUrl     string `yaml:"icon_url"`
+}
+
+func (c *MisskeyConfig) GetType() string {
+	return c.Type
+}

--- a/internal/config/misskey.go
+++ b/internal/config/misskey.go
@@ -16,9 +16,9 @@ type MisskeyConfig struct {
 	Type        string
 	InstanceUrl string `yaml:"instance_url"`
 	UserId      string `yaml:"user_id"`
-	SiteUrl     string `yaml:"site_url,omitempty"`
-	Name        string `yaml:"name,omitempty"`
-	IconUrl     string `yaml:"icon_url,omitempty"`
+	SiteUrl     string `yaml:"site_url"`
+	Name        string `yaml:"name"`
+	IconUrl     string `yaml:"icon_url"`
 }
 
 func (c *MisskeyConfig) SetId(id string) {

--- a/internal/config/misskey.go
+++ b/internal/config/misskey.go
@@ -1,16 +1,75 @@
 package config
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antchfx/htmlquery"
+	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
+)
+
 type MisskeyConfig struct {
-	Type        string `yaml:"type"`
-	Id          string `yaml:"id"`
+	Id          string
+	Type        string
 	InstanceUrl string `yaml:"instance_url"`
 	UserId      string `yaml:"user_id"`
-	SourceUrl   string `yaml:"source_url"`
-	SiteUrl     string `yaml:"site_url"`
-	Name        string `yaml:"name"`
-	IconUrl     string `yaml:"icon_url"`
+	SiteUrl     string `yaml:"site_url,omitempty"`
+	Name        string `yaml:"name,omitempty"`
+	IconUrl     string `yaml:"icon_url,omitempty"`
+}
+
+func (c *MisskeyConfig) SetId(id string) {
+	c.Id = id
+}
+
+func (c *MisskeyConfig) SetType(typ string) {
+	c.Type = typ
 }
 
 func (c *MisskeyConfig) GetType() string {
 	return c.Type
+}
+
+func (c *MisskeyConfig) CompleteMetadata(ctx context.Context, id string) error {
+	if len(c.InstanceUrl) == 0 {
+		return errors.New("instance_url is required")
+	}
+	if len(c.SiteUrl) == 0 {
+		return fmt.Errorf("%s: site_url is undefined", id)
+	}
+	client := new(http.Client)
+	reqUrl, err := url.Parse(c.SiteUrl)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	doc, err := htmlquery.Parse(resp.Body)
+	if err != nil {
+		return err
+	}
+	if len(c.Name) == 0 {
+		titleElem := htmlquery.FindOne(doc, `//title/text()`)
+		c.Name = htmlquery.InnerText(titleElem)
+	}
+	if len(c.IconUrl) == 0 {
+		iconUrlElem := htmlquery.FindOne(doc, `//link[@rel="icon"]/@href`)
+		iconUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(iconUrlElem))
+		if err != nil {
+			return err
+		}
+		c.IconUrl = iconUrl.String()
+	}
+	return nil
 }

--- a/internal/config/misskey.go
+++ b/internal/config/misskey.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/antchfx/htmlquery"
+	"github.com/eniehack/planet-someone/internal/hb"
 	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
 )
 
@@ -72,4 +73,12 @@ func (c *MisskeyConfig) CompleteMetadata(ctx context.Context, id string) error {
 		c.IconUrl = iconUrl.String()
 	}
 	return nil
+}
+
+func (c *MisskeyConfig) GetMetadata() *hb.Site {
+	return &hb.Site{
+		Url:     c.SiteUrl,
+		IconUrl: c.IconUrl,
+		Title:   c.Name,
+	}
 }

--- a/internal/config/scrapbox.go
+++ b/internal/config/scrapbox.go
@@ -1,0 +1,14 @@
+package config
+
+type ScrapboxConfig struct {
+	Type      string `yaml:"type"`
+	Id        string `yaml:"id"`
+	SourceUrl string `yaml:"source_url"`
+	SiteUrl   string `yaml:"site_url"`
+	Name      string `yaml:"name"`
+	IconUrl   string `yaml:"icon_url"`
+}
+
+func (c *ScrapboxConfig) GetType() string {
+	return c.Type
+}

--- a/internal/config/scrapbox.go
+++ b/internal/config/scrapbox.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/antchfx/htmlquery"
+	"github.com/eniehack/planet-someone/internal/hb"
 	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
 )
 
@@ -76,4 +77,12 @@ func (c *ScrapboxConfig) CompleteMetadata(ctx context.Context, id string) error 
 		c.IconUrl = iconUrl.String()
 	}
 	return nil
+}
+
+func (c *ScrapboxConfig) GetMetadata() *hb.Site {
+	return &hb.Site{
+		Url:     c.SiteUrl,
+		IconUrl: c.IconUrl,
+		Title:   c.Name,
+	}
 }

--- a/internal/config/scrapbox.go
+++ b/internal/config/scrapbox.go
@@ -1,14 +1,79 @@
 package config
 
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antchfx/htmlquery"
+	pkgUrl "github.com/eniehack/planet-someone/pkg/url"
+)
+
 type ScrapboxConfig struct {
-	Type      string `yaml:"type"`
-	Id        string `yaml:"id"`
-	SourceUrl string `yaml:"source_url"`
+	Id        string `yaml:"-"`
+	Type      string `yaml:"-"`
+	SourceUrl string `yaml:"source_url,omitempty"`
 	SiteUrl   string `yaml:"site_url"`
-	Name      string `yaml:"name"`
-	IconUrl   string `yaml:"icon_url"`
+	Name      string `yaml:"name,omitempty"`
+	IconUrl   string `yaml:"icon_url,omitempty"`
+}
+
+func (c *ScrapboxConfig) SetId(id string) {
+	c.Id = id
+}
+
+func (c *ScrapboxConfig) SetType(typ string) {
+	c.Type = typ
 }
 
 func (c *ScrapboxConfig) GetType() string {
 	return c.Type
+}
+
+func (c *ScrapboxConfig) CompleteMetadata(ctx context.Context, id string) error {
+	fmt.Printf("c: %+v", c)
+	if len(c.SiteUrl) == 0 {
+		return fmt.Errorf("%s: site_url is undefined", id)
+	}
+	client := new(http.Client)
+	reqUrl, err := url.Parse(c.SiteUrl)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	doc, err := htmlquery.Parse(resp.Body)
+	if err != nil {
+		return err
+	}
+	if len(c.Name) == 0 {
+		titleElem := htmlquery.FindOne(doc, `//title/text()`)
+		c.Name = htmlquery.InnerText(titleElem)
+	}
+	if len(c.SourceUrl) == 0 {
+		feedUrlElem := htmlquery.FindOne(doc, `//link[@rel="alternate" and (@type="application/rss+xml" or @type="application/atom+xml")]/@href`)
+		srcUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(feedUrlElem))
+		if err != nil {
+			return err
+		}
+		c.SourceUrl = srcUrl.String()
+	}
+	if len(c.IconUrl) == 0 {
+		iconUrlElem := htmlquery.FindOne(doc, `//link[@rel="icon"]/@href`)
+		iconUrl, err := pkgUrl.ResolveAbsUrl(reqUrl, htmlquery.InnerText(iconUrlElem))
+		if err != nil {
+			return err
+		}
+		c.IconUrl = iconUrl.String()
+	}
+	return nil
 }

--- a/internal/config/scrapbox.go
+++ b/internal/config/scrapbox.go
@@ -13,10 +13,10 @@ import (
 type ScrapboxConfig struct {
 	Id        string `yaml:"-"`
 	Type      string `yaml:"-"`
-	SourceUrl string `yaml:"source_url,omitempty"`
+	SourceUrl string `yaml:"source_url"`
 	SiteUrl   string `yaml:"site_url"`
-	Name      string `yaml:"name,omitempty"`
-	IconUrl   string `yaml:"icon_url,omitempty"`
+	Name      string `yaml:"name"`
+	IconUrl   string `yaml:"icon_url"`
 }
 
 func (c *ScrapboxConfig) SetId(id string) {

--- a/internal/hb/hb.go
+++ b/internal/hb/hb.go
@@ -1,0 +1,32 @@
+package hb
+
+import "time"
+
+type Post struct {
+	Id         string
+	Content    string
+	Url        string
+	Date       int64
+	ParsedDate *time.Time
+	Src        string
+}
+
+type PageMeta struct {
+	Url         string
+	Description string
+	Title       string
+}
+
+type Config struct {
+	Meta PageMeta
+}
+
+type BinMeta struct {
+	Version string
+}
+
+type Site struct {
+	Url     string
+	IconUrl string
+	Title   string
+}

--- a/internal/picker/base.go
+++ b/internal/picker/base.go
@@ -1,7 +1,6 @@
 package picker
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -15,21 +14,6 @@ type BaseHandler struct {
 
 type Handler interface {
 	ReadLastRunTime(dur *time.Duration) (*time.Time, error)
-}
-
-func (h *BaseHandler) ReadLastRunTime(dur *time.Duration) (*time.Time, error) {
-	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.Config.Id)
-	if row.Err() != nil {
-		if row.Err() == sql.ErrNoRows {
-			t := time.Now().Add(*dur)
-			return &t, row.Err()
-		}
-		return nil, row.Err()
-	}
-	var timestamp_unit int64
-	row.Scan(&timestamp_unit)
-	timestamp := time.Unix(timestamp_unit, 0)
-	return &timestamp, nil
 }
 
 func (h *BaseHandler) SaveLastRunTime(t time.Time, src int) error {

--- a/internal/picker/base.go
+++ b/internal/picker/base.go
@@ -4,19 +4,21 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/eniehack/planet-someone/internal/config"
 	"github.com/jmoiron/sqlx"
 )
 
 var DEFAULT_DURATION time.Duration = time.Hour * 24 * 14
 
 type BaseHandler struct {
-	DB         *sqlx.DB
-	SiteConfig *config.SiteConfig
+	DB *sqlx.DB
+}
+
+type Handler interface {
+	ReadLastRunTime(dur *time.Duration) (*time.Time, error)
 }
 
 func (h *BaseHandler) ReadLastRunTime(dur *time.Duration) (*time.Time, error) {
-	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.SiteConfig.Id)
+	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.Config.Id)
 	if row.Err() != nil {
 		if row.Err() == sql.ErrNoRows {
 			t := time.Now().Add(*dur)

--- a/internal/picker/blog.go
+++ b/internal/picker/blog.go
@@ -5,11 +5,13 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/eniehack/planet-someone/internal/config"
 	"github.com/mmcdole/gofeed"
 )
 
 type BlogHandler struct {
 	BaseHandler
+	Config *config.BlogConfig
 }
 
 func (h *BlogHandler) Pick() error {
@@ -17,7 +19,7 @@ func (h *BlogHandler) Pick() error {
 	if err != nil {
 		slog.Info(fmt.Sprintf("Error reading last run time: %s", err))
 	}
-	feed, err := gofeed.NewParser().ParseURL(h.SiteConfig.SourceUrl)
+	feed, err := gofeed.NewParser().ParseURL(h.Config.SourceUrl)
 	if err != nil {
 		return fmt.Errorf("error parsing rss feed: %s", err)
 	}
@@ -30,7 +32,7 @@ func (h *BlogHandler) Pick() error {
 		fmt.Printf("lastrun: %s, published: %s\n", lastRun.Format(time.RFC3339), item.PublishedParsed.Format(time.RFC3339))
 		if lastRun.Unix() < item.PublishedParsed.Unix() {
 			id := BuildID(item.PublishedParsed)
-			if _, err := stmt.Exec(id, item.Title, item.Link, h.SiteConfig.Id, item.PublishedParsed.Unix()); err != nil {
+			if _, err := stmt.Exec(id, item.Title, item.Link, h.Config.Id, item.PublishedParsed.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", item.Link, err)
 			}
 		}

--- a/internal/picker/blog.go
+++ b/internal/picker/blog.go
@@ -1,6 +1,7 @@
 package picker
 
 import (
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"time"
@@ -38,4 +39,19 @@ func (h *BlogHandler) Pick() error {
 		}
 	}
 	return nil
+}
+
+func (h *BlogHandler) ReadLastRunTime(dur *time.Duration) (*time.Time, error) {
+	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.Config.Id)
+	if row.Err() != nil {
+		if row.Err() == sql.ErrNoRows {
+			t := time.Now().Add(*dur)
+			return &t, row.Err()
+		}
+		return nil, row.Err()
+	}
+	var timestamp_unit int64
+	row.Scan(&timestamp_unit)
+	timestamp := time.Unix(timestamp_unit, 0)
+	return &timestamp, nil
 }

--- a/internal/picker/blog.go
+++ b/internal/picker/blog.go
@@ -24,7 +24,7 @@ func (h *BlogHandler) Pick() error {
 	if err != nil {
 		return fmt.Errorf("error parsing rss feed: %s", err)
 	}
-	stmt, err := h.DB.Prepare("INSERT INTO posts (id, title, url, src, created_at) VALUES (?, ?, ?, ?, ?);")
+	stmt, err := h.DB.Prepare("INSERT INTO posts (id, content, url, src, type, created_at) VALUES (?, ?, ?, ?, ?, ?);")
 	if err != nil {
 		return fmt.Errorf("cannot make prepare statement: %s", err)
 	}
@@ -33,7 +33,7 @@ func (h *BlogHandler) Pick() error {
 		fmt.Printf("lastrun: %s, published: %s\n", lastRun.Format(time.RFC3339), item.PublishedParsed.Format(time.RFC3339))
 		if lastRun.Unix() < item.PublishedParsed.Unix() {
 			id := BuildID(item.PublishedParsed)
-			if _, err := stmt.Exec(id, item.Title, item.Link, h.Config.Id, item.PublishedParsed.Unix()); err != nil {
+			if _, err := stmt.Exec(id, item.Title, item.Link, h.Config.Id, h.Config.Type, item.PublishedParsed.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", item.Link, err)
 			}
 		}

--- a/internal/picker/mastodon.go
+++ b/internal/picker/mastodon.go
@@ -24,6 +24,7 @@ type MastodonUserStatusAPIResponse struct {
 
 type MastodonHandler struct {
 	BaseHandler
+	Config *config.MastodonConfig
 }
 
 func (h *MastodonHandler) Pick() error {
@@ -49,7 +50,7 @@ func (h *MastodonHandler) Pick() error {
 		if lastRun.Unix() < published.Unix() && !item.Sensitive {
 			id := BuildID(&published)
 			content := buildContent(item.Content)
-			if _, err := stmt.Exec(id, content, item.Url, h.SiteConfig.Id, published.Unix()); err != nil {
+			if _, err := stmt.Exec(id, content, item.Url, h.Config.Id, published.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", item.Url, err)
 			}
 		}

--- a/internal/picker/mastodon.go
+++ b/internal/picker/mastodon.go
@@ -1,6 +1,7 @@
 package picker
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -15,11 +16,12 @@ import (
 )
 
 type MastodonUserStatusAPIResponse struct {
-	Id        string `json:"id"`
-	Sensitive bool   `json:"sensitive"`
-	CreatedAt string `json:"created_at"`
-	Url       string `json:"url"`
-	Content   string `json:"content"`
+	Id        string                         `json:"id"`
+	Sensitive bool                           `json:"sensitive"`
+	CreatedAt string                         `json:"created_at"`
+	Url       string                         `json:"url"`
+	Content   string                         `json:"content"`
+	Reblog    *MastodonUserStatusAPIResponse `json:"reblog,omitempty"`
 }
 
 type MastodonHandler struct {
@@ -72,13 +74,13 @@ func buildContent(rawContent string) string {
 }
 
 func (h MastodonHandler) Fetch() (*[]MastodonUserStatusAPIResponse, error) {
-	reqUrl, err := url.Parse(h.SiteConfig.SourceUrl)
+	reqUrl, err := url.Parse(h.Config.SourceUrl)
 	if err != nil {
 		return nil, err
 	}
 	query := make(url.Values)
 	query.Add("exclude_replies", "true")
-	query.Add("exclude_reblogs", "true")
+	//query.Add("exclude_reblogs", "true")
 	reqUrl.RawQuery = query.Encode()
 	client := new(http.Client)
 	req, err := http.NewRequest(http.MethodGet, reqUrl.String(), nil)
@@ -97,4 +99,19 @@ func (h MastodonHandler) Fetch() (*[]MastodonUserStatusAPIResponse, error) {
 		return nil, err
 	}
 	return &respPayload, nil
+}
+
+func (h *MastodonHandler) ReadLastRunTime(dur *time.Duration) (*time.Time, error) {
+	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.Config.Id)
+	if row.Err() != nil {
+		if row.Err() == sql.ErrNoRows {
+			t := time.Now().Add(*dur)
+			return &t, row.Err()
+		}
+		return nil, row.Err()
+	}
+	var timestamp_unit int64
+	row.Scan(&timestamp_unit)
+	timestamp := time.Unix(timestamp_unit, 0)
+	return &timestamp, nil
 }

--- a/internal/picker/mastodon.go
+++ b/internal/picker/mastodon.go
@@ -159,7 +159,7 @@ func (h MastodonHandler) Fetch() (*[]MastodonUserStatusAPIResponse, error) {
 	req.Header.Set("User-Agent", config.UserAgent)
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error access Misskey API: %s", err)
+		return nil, fmt.Errorf("error access Mastodon API: %s", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/picker/mastodon.go
+++ b/internal/picker/mastodon.go
@@ -8,11 +8,12 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
-	"github.com/antchfx/htmlquery"
 	"github.com/eniehack/planet-someone/internal/config"
+	"golang.org/x/net/html"
 )
 
 type MastodonUserStatusAPIResponse struct {
@@ -38,7 +39,7 @@ func (h *MastodonHandler) Pick() error {
 	if err != nil {
 		return err
 	}
-	stmt, err := h.DB.Prepare("INSERT INTO posts (id, title, url, src, created_at) VALUES (?, ?, ?, ?, ?);")
+	stmt, err := h.DB.Prepare("INSERT INTO posts (id, content, url, src, type, created_at) VALUES (?, ?, ?, ?, ?, ?);")
 	if err != nil {
 		return fmt.Errorf("cannot make prepare statement: %s", err)
 	}
@@ -51,8 +52,21 @@ func (h *MastodonHandler) Pick() error {
 		}
 		if lastRun.Unix() < published.Unix() && !item.Sensitive {
 			id := BuildID(&published)
-			content := buildContent(item.Content)
-			if _, err := stmt.Exec(id, content, item.Url, h.Config.Id, published.Unix()); err != nil {
+			var content string
+			if item.Reblog == nil {
+				node, err := html.Parse(strings.NewReader(item.Content))
+				if err != nil {
+					return err
+				}
+				content = buildContent(node, true)
+			} else {
+				node, err := html.Parse(strings.NewReader(item.Reblog.Content))
+				if err != nil {
+					return err
+				}
+				content = fmt.Sprintf("BT: %s", buildContent(node, true))
+			}
+			if _, err := stmt.Exec(id, content, item.Url, h.Config.Id, h.Config.Type, published.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", item.Url, err)
 			}
 		}
@@ -60,17 +74,61 @@ func (h *MastodonHandler) Pick() error {
 	return nil
 }
 
-func buildContent(rawContent string) string {
-	brReplacedContent := strings.ReplaceAll(rawContent, "<br />", "\n")
-	contentDoc, err := htmlquery.Parse(strings.NewReader(brReplacedContent))
-	if err != nil {
-		log.Println("cannot parse html:", err)
+func buildContent(node *html.Node, insertContentFlag bool) string {
+	var content strings.Builder
+
+	if node.Type == html.ElementNode {
+		switch node.Data {
+		case "a":
+			cls := getClassList(node)
+			if !slices.Contains(cls, "hashtag") {
+				if href := getAttribute(node, "href"); href != "" {
+					content.WriteString(href)
+					insertContentFlag = false
+				}
+			} else {
+				insertContentFlag = true
+			}
+		case "br":
+			content.WriteString("\n")
+		case "span":
+			cls := getClassList(node)
+			if slices.Contains(cls, "invisible") || slices.Contains(cls, "ellipsis") {
+				insertContentFlag = false
+			}
+		}
 	}
-	content := new(strings.Builder)
-	for _, elem := range htmlquery.Find(contentDoc, "//text()") {
-		content.WriteString(htmlquery.InnerText(elem) + " ")
+
+	if node.Type == html.TextNode && insertContentFlag {
+		content.WriteString(node.Data + " ")
 	}
+
+	// 子ノードを再帰的に処理
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		content.WriteString(buildContent(child, insertContentFlag))
+	}
+
 	return content.String()
+}
+
+// ヘルパー関数: class属性を取得してスライスに変換
+func getClassList(node *html.Node) []string {
+	for _, attr := range node.Attr {
+		if attr.Key == "class" {
+			return strings.Fields(attr.Val)
+		}
+	}
+	return []string{}
+}
+
+// ヘルパー関数: 指定した属性値を取得
+func getAttribute(node *html.Node, key string) string {
+	for _, attr := range node.Attr {
+		if attr.Key == key {
+			return attr.Val
+		}
+	}
+	return ""
 }
 
 func (h MastodonHandler) Fetch() (*[]MastodonUserStatusAPIResponse, error) {
@@ -78,10 +136,12 @@ func (h MastodonHandler) Fetch() (*[]MastodonUserStatusAPIResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(reqUrl.String())
 	query := make(url.Values)
 	query.Add("exclude_replies", "true")
 	//query.Add("exclude_reblogs", "true")
 	reqUrl.RawQuery = query.Encode()
+	fmt.Println(reqUrl.String())
 	client := new(http.Client)
 	req, err := http.NewRequest(http.MethodGet, reqUrl.String(), nil)
 	if err != nil {

--- a/internal/picker/mastodon.go
+++ b/internal/picker/mastodon.go
@@ -16,12 +16,18 @@ import (
 	"golang.org/x/net/html"
 )
 
+type MastodonAccountAPIResponse struct {
+	Indexable bool   `json:"indexable"`
+	Acct      string `json:"acct"`
+}
+
 type MastodonUserStatusAPIResponse struct {
 	Id        string                         `json:"id"`
 	Sensitive bool                           `json:"sensitive"`
 	CreatedAt string                         `json:"created_at"`
 	Url       string                         `json:"url"`
 	Content   string                         `json:"content"`
+	Account   *MastodonAccountAPIResponse    `json:"account"`
 	Reblog    *MastodonUserStatusAPIResponse `json:"reblog,omitempty"`
 }
 
@@ -59,15 +65,18 @@ func (h *MastodonHandler) Pick() error {
 					return err
 				}
 				content = buildContent(node, true)
+				if _, err := stmt.Exec(id, content, item.Url, h.Config.Id, h.Config.Type, published.Unix()); err != nil {
+					return fmt.Errorf("cannot insert item(%s): %s", item.Url, err)
+				}
 			} else {
 				node, err := html.Parse(strings.NewReader(item.Reblog.Content))
 				if err != nil {
 					return err
 				}
-				content = fmt.Sprintf("BT: %s", buildContent(node, true))
-			}
-			if _, err := stmt.Exec(id, content, item.Url, h.Config.Id, h.Config.Type, published.Unix()); err != nil {
-				return fmt.Errorf("cannot insert item(%s): %s", item.Url, err)
+				content = fmt.Sprintf("BT %s: %s", item.Account.Acct, buildContent(node, true))
+				if _, err := stmt.Exec(id, content, item.Reblog.Url, h.Config.Id, h.Config.Type, published.Unix()); err != nil {
+					return fmt.Errorf("cannot insert item(%s): %s", item.Url, err)
+				}
 			}
 		}
 	}

--- a/internal/picker/mastodon.go
+++ b/internal/picker/mastodon.go
@@ -73,7 +73,7 @@ func (h *MastodonHandler) Pick() error {
 				if err != nil {
 					return err
 				}
-				content = fmt.Sprintf("BT %s: %s", item.Account.Acct, buildContent(node, true))
+				content = fmt.Sprintf("BT %s: %s", item.Reblog.Account.Acct, buildContent(node, true))
 				if _, err := stmt.Exec(id, content, item.Reblog.Url, h.Config.Id, h.Config.Type, published.Unix()); err != nil {
 					return fmt.Errorf("cannot insert item(%s): %s", item.Url, err)
 				}

--- a/internal/picker/misskey.go
+++ b/internal/picker/misskey.go
@@ -16,6 +16,7 @@ import (
 
 type MisskeyHandler struct {
 	BaseHandler
+	Config *config.MisskeyConfig
 }
 
 type MisskeyAPIRequestPayload struct {
@@ -38,7 +39,7 @@ func (h *MisskeyHandler) Pick() error {
 	if err != nil {
 		slog.Info(fmt.Sprintf("Error reading last run time: %s", err))
 	}
-	reqUrl, err := url.Parse(h.SiteConfig.SiteUrl)
+	reqUrl, err := url.Parse(h.Config.InstanceUrl)
 	if err != nil {
 		return fmt.Errorf("cannot parse url: %s", err)
 	}
@@ -61,7 +62,7 @@ func (h *MisskeyHandler) Pick() error {
 		if lastRun.Unix() < published.Unix() && item.ContentWarning == nil {
 			id := BuildID(&published)
 			link := fmt.Sprintf("https://%s/notes/%s", reqUrl.Host, item.Id)
-			if _, err := stmt.Exec(id, item.Text, link, h.SiteConfig.Id, published.Unix()); err != nil {
+			if _, err := stmt.Exec(id, item.Text, link, h.Config.Id, published.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", link, err)
 			}
 		}
@@ -71,7 +72,7 @@ func (h *MisskeyHandler) Pick() error {
 
 func (h *MisskeyHandler) Fetch(reqUrl *url.URL, lastRun *time.Time) (*[]MisskeyAPIResponsePayload, error) {
 	reqPayload := &MisskeyAPIRequestPayload{
-		UserId:       h.SiteConfig.SourceUrl,
+		UserId:       h.Config.UserId,
 		WithReplies:  false,
 		WithRenotes:  false,
 		UntilDate:    lastRun.UnixMilli(),

--- a/internal/picker/misskey.go
+++ b/internal/picker/misskey.go
@@ -49,7 +49,7 @@ func (h *MisskeyHandler) Pick() error {
 	if err != nil {
 		return fmt.Errorf("cannot fetch misskey posts: %s", err)
 	}
-	stmt, err := h.DB.Prepare("INSERT INTO posts (id, title, url, src, created_at) VALUES (?, ?, ?, ?, ?);")
+	stmt, err := h.DB.Prepare("INSERT INTO posts (id, content, url, src, type, created_at) VALUES (?, ?, ?, ?, ?, ?);")
 	if err != nil {
 		return fmt.Errorf("cannot make prepare statement: %s", err)
 	}
@@ -63,7 +63,7 @@ func (h *MisskeyHandler) Pick() error {
 		if lastRun.Unix() < published.Unix() && item.ContentWarning == nil {
 			id := BuildID(&published)
 			link := fmt.Sprintf("https://%s/notes/%s", reqUrl.Host, item.Id)
-			if _, err := stmt.Exec(id, item.Text, link, h.Config.Id, published.Unix()); err != nil {
+			if _, err := stmt.Exec(id, item.Text, link, h.Config.Id, h.Config.Type, published.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", link, err)
 			}
 		}

--- a/internal/picker/misskey.go
+++ b/internal/picker/misskey.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -111,4 +112,19 @@ func (h *MisskeyHandler) Fetch(reqUrl *url.URL, lastRun *time.Time) (*[]MisskeyA
 		return nil, err
 	}
 	return &respPayload, nil
+}
+
+func (h *MisskeyHandler) ReadLastRunTime(dur *time.Duration) (*time.Time, error) {
+	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.Config.Id)
+	if row.Err() != nil {
+		if row.Err() == sql.ErrNoRows {
+			t := time.Now().Add(*dur)
+			return &t, row.Err()
+		}
+		return nil, row.Err()
+	}
+	var timestamp_unit int64
+	row.Scan(&timestamp_unit)
+	timestamp := time.Unix(timestamp_unit, 0)
+	return &timestamp, nil
 }

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -34,6 +34,8 @@ func PickerFactory(db *sqlx.DB, src config.SiteConfigWrapper) (FeedPicker, error
 		if !ok {
 			return nil, ErrCannotCastConfigStruct
 		}
+		config.Id = src.Id
+		config.Type = src.Type
 		h.Config = config
 		return h, nil
 	case model.TYPE_SCRAPBOX:
@@ -43,6 +45,8 @@ func PickerFactory(db *sqlx.DB, src config.SiteConfigWrapper) (FeedPicker, error
 		if !ok {
 			return nil, ErrCannotCastConfigStruct
 		}
+		config.Id = src.Id
+		config.Type = src.Type
 		h.Config = config
 		return h, nil
 	case model.TYPE_BLOG:
@@ -52,6 +56,8 @@ func PickerFactory(db *sqlx.DB, src config.SiteConfigWrapper) (FeedPicker, error
 		if !ok {
 			return nil, ErrCannotCastConfigStruct
 		}
+		config.Id = src.Id
+		config.Type = src.Type
 		h.Config = config
 		return h, nil
 	case model.TYPE_MISSKEY:
@@ -61,6 +67,8 @@ func PickerFactory(db *sqlx.DB, src config.SiteConfigWrapper) (FeedPicker, error
 		if !ok {
 			return nil, ErrCannotCastConfigStruct
 		}
+		config.Id = src.Id
+		config.Type = src.Type
 		h.Config = config
 		return h, nil
 	default:

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/eniehack/planet-someone/internal/config"
-	"github.com/eniehack/planet-someone/internal/model"
 	"github.com/jmoiron/sqlx"
 	"github.com/oklog/ulid/v2"
 )
@@ -22,30 +21,30 @@ type Source struct {
 	Type      int    `db:"type"`
 }
 
-func PickerFactory(db *sqlx.DB, src *config.SiteConfig) (FeedPicker, error) {
-	switch src.Type {
-	case model.TYPE_MASTODON:
+func PickerFactory(db *sqlx.DB, src config.SiteConfig) (FeedPicker, error) {
+	switch config := src.(type) {
+	case *config.MastodonConfig:
 		h := new(MastodonHandler)
 		h.DB = db
-		h.SiteConfig = src
+		h.Config = config
 		return h, nil
-	case model.TYPE_MISSKEY:
-		h := new(MisskeyHandler)
-		h.DB = db
-		h.SiteConfig = src
-		return h, nil
-	case model.TYPE_SCRAPBOX:
+	case *config.ScrapboxConfig:
 		h := new(ScrapboxHandler)
 		h.DB = db
-		h.SiteConfig = src
+		h.Config = config
 		return h, nil
-	case model.TYPE_BLOG:
+	case *config.BlogConfig:
 		h := new(BlogHandler)
 		h.DB = db
-		h.SiteConfig = src
+		h.Config = config
+		return h, nil
+	case *config.MisskeyConfig:
+		h := new(MisskeyHandler)
+		h.DB = db
+		h.Config = config
 		return h, nil
 	default:
-		return nil, fmt.Errorf("unsupported type site: %s", src.Id)
+		return nil, fmt.Errorf("unsupported type site: %s", config.GetType())
 	}
 }
 

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -1,10 +1,12 @@
 package picker
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/eniehack/planet-someone/internal/config"
+	"github.com/eniehack/planet-someone/internal/model"
 	"github.com/jmoiron/sqlx"
 	"github.com/oklog/ulid/v2"
 )
@@ -21,30 +23,48 @@ type Source struct {
 	Type      int    `db:"type"`
 }
 
-func PickerFactory(db *sqlx.DB, src config.SiteConfig) (FeedPicker, error) {
-	switch config := src.(type) {
-	case *config.MastodonConfig:
+var ErrCannotCastConfigStruct = errors.New("cannot cast config")
+
+func PickerFactory(db *sqlx.DB, src config.SiteConfigWrapper) (FeedPicker, error) {
+	switch src.Type {
+	case model.TYPE_MASTODON:
 		h := new(MastodonHandler)
 		h.DB = db
+		config, ok := src.RawParams.(*config.MastodonConfig)
+		if !ok {
+			return nil, ErrCannotCastConfigStruct
+		}
 		h.Config = config
 		return h, nil
-	case *config.ScrapboxConfig:
+	case model.TYPE_SCRAPBOX:
 		h := new(ScrapboxHandler)
 		h.DB = db
+		config, ok := src.RawParams.(*config.ScrapboxConfig)
+		if !ok {
+			return nil, ErrCannotCastConfigStruct
+		}
 		h.Config = config
 		return h, nil
-	case *config.BlogConfig:
+	case model.TYPE_BLOG:
 		h := new(BlogHandler)
 		h.DB = db
+		config, ok := src.RawParams.(*config.BlogConfig)
+		if !ok {
+			return nil, ErrCannotCastConfigStruct
+		}
 		h.Config = config
 		return h, nil
-	case *config.MisskeyConfig:
+	case model.TYPE_MISSKEY:
 		h := new(MisskeyHandler)
 		h.DB = db
+		config, ok := src.RawParams.(*config.MisskeyConfig)
+		if !ok {
+			return nil, ErrCannotCastConfigStruct
+		}
 		h.Config = config
 		return h, nil
 	default:
-		return nil, fmt.Errorf("unsupported type site: %s", config.GetType())
+		return nil, fmt.Errorf("unsupported type site: %s", src.Type)
 	}
 }
 

--- a/internal/picker/scrapbox.go
+++ b/internal/picker/scrapbox.go
@@ -24,7 +24,7 @@ func (h *ScrapboxHandler) Pick() error {
 	if err != nil {
 		return fmt.Errorf("error parsing rss feed: %s", err)
 	}
-	stmt, err := h.DB.Prepare("INSERT INTO posts (id, title, url, src, created_at) VALUES (?, ?, ?, ?, ?);")
+	stmt, err := h.DB.Prepare("INSERT INTO posts (id, title, url, src, type, created_at) VALUES (?, ?, ?, ?, ?, ?);")
 	if err != nil {
 		return fmt.Errorf("cannot make prepare statement: %s", err)
 	}
@@ -32,7 +32,7 @@ func (h *ScrapboxHandler) Pick() error {
 	for _, item := range feed.Items {
 		if lastRun.Unix() < item.PublishedParsed.Unix() {
 			id := BuildID(item.PublishedParsed)
-			if _, err := stmt.Exec(id, item.Title, item.Link, h.Config.Id, item.PublishedParsed.Unix()); err != nil {
+			if _, err := stmt.Exec(id, item.Title, item.Link, h.Config.Id, h.Config.Type, item.PublishedParsed.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", item.Link, err)
 			}
 		}

--- a/internal/picker/scrapbox.go
+++ b/internal/picker/scrapbox.go
@@ -24,7 +24,7 @@ func (h *ScrapboxHandler) Pick() error {
 	if err != nil {
 		return fmt.Errorf("error parsing rss feed: %s", err)
 	}
-	stmt, err := h.DB.Prepare("INSERT INTO posts (id, title, url, src, type, created_at) VALUES (?, ?, ?, ?, ?, ?);")
+	stmt, err := h.DB.Prepare("INSERT INTO posts (id, content, url, src, type, created_at) VALUES (?, ?, ?, ?, ?, ?);")
 	if err != nil {
 		return fmt.Errorf("cannot make prepare statement: %s", err)
 	}

--- a/internal/picker/scrapbox.go
+++ b/internal/picker/scrapbox.go
@@ -1,8 +1,10 @@
 package picker
 
 import (
+	"database/sql"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/eniehack/planet-someone/internal/config"
 	"github.com/mmcdole/gofeed"
@@ -36,4 +38,19 @@ func (h *ScrapboxHandler) Pick() error {
 		}
 	}
 	return nil
+}
+
+func (h *ScrapboxHandler) ReadLastRunTime(dur *time.Duration) (*time.Time, error) {
+	row := h.DB.QueryRow("SELECT created_at FROM posts WHERE src = ? ORDER BY created_at DESC;", h.Config.Id)
+	if row.Err() != nil {
+		if row.Err() == sql.ErrNoRows {
+			t := time.Now().Add(*dur)
+			return &t, row.Err()
+		}
+		return nil, row.Err()
+	}
+	var timestamp_unit int64
+	row.Scan(&timestamp_unit)
+	timestamp := time.Unix(timestamp_unit, 0)
+	return &timestamp, nil
 }

--- a/internal/picker/scrapbox.go
+++ b/internal/picker/scrapbox.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/eniehack/planet-someone/internal/config"
 	"github.com/mmcdole/gofeed"
 )
 
 type ScrapboxHandler struct {
 	BaseHandler
+	Config *config.ScrapboxConfig
 }
 
 func (h *ScrapboxHandler) Pick() error {
@@ -16,7 +18,7 @@ func (h *ScrapboxHandler) Pick() error {
 	if err != nil {
 		slog.Info(fmt.Sprintf("Error reading last run time: %s", err))
 	}
-	feed, err := gofeed.NewParser().ParseURL(h.SiteConfig.SourceUrl)
+	feed, err := gofeed.NewParser().ParseURL(h.Config.SourceUrl)
 	if err != nil {
 		return fmt.Errorf("error parsing rss feed: %s", err)
 	}
@@ -28,7 +30,7 @@ func (h *ScrapboxHandler) Pick() error {
 	for _, item := range feed.Items {
 		if lastRun.Unix() < item.PublishedParsed.Unix() {
 			id := BuildID(item.PublishedParsed)
-			if _, err := stmt.Exec(id, item.Title, item.Link, h.SiteConfig.Id, item.PublishedParsed.Unix()); err != nil {
+			if _, err := stmt.Exec(id, item.Title, item.Link, h.Config.Id, item.PublishedParsed.Unix()); err != nil {
 				return fmt.Errorf("cannot insert item(%s): %s", item.Link, err)
 			}
 		}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -1,0 +1,12 @@
+package url
+
+import "net/url"
+
+func ResolveAbsUrl(baseUrl *url.URL, path string) (*url.URL, error) {
+	relUrl, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	abs := baseUrl.ResolveReference(relUrl)
+	return abs, nil
+}

--- a/template/index.html
+++ b/template/index.html
@@ -31,9 +31,9 @@
 </head>
 <body>
     <div class="@container">
-        <main class="mx-auto w-full @xl:max-w-[540px] @3xl:max-w-[720px] @5xl:max-w-[960px] @7xl:max-w-[1140px]">
+        <main class="pl-4 pr-8 mx-auto w-[calc(100% - 20px)] @xl:max-w-[540px] @3xl:max-w-[720px] @5xl:max-w-[960px] @7xl:max-w-[1140px]">
             <article>
-                <h1 class="text-5xl font-black my-[21px]">planet eniehack</h1>
+                <h1 class="text-5xl font-black my-[21px] py-10">planet eniehack</h1>
                 <p>
                     <a href="https://planet.debian.org/">Planet Debian</a>や<a href="https://kanzaki.com/info/planet">Planet masaka</a>のように、僕個人の最新情報を1つのページにまとめたものです。
                 </p>
@@ -41,7 +41,7 @@
                     データソースは以下の通りです:
                     <ul>
                         {{ range $k, $v := .Sites}}
-                            <li>
+                            <li class="align-middle">
                                 <img class="inline" src="{{- $v.IconUrl -}}" width="16" height="16"/>
                                 <a class="" href="{{- $v.Url -}}">
                                     {{$v.Title}}
@@ -75,7 +75,7 @@
                 {{ end -}}
             </article>
         </main> 
-        <footer class="mx-auto">
+        <footer class="mx-auto pl-4 pr-8">
              <p><a href="https://github.com/eniehack/planet-someone">planet-someone</a>(revision: {{ $.Meta.Version }})</p>
         </footer>
     </div>

--- a/template/index.html
+++ b/template/index.html
@@ -13,58 +13,70 @@
 	<meta name="twitter:description" content="{{- .Config.Meta.Description -}}" />
 	<meta name="twitter:creators" content="@eniehack" />
 	<meta name="twitter:card" content="summary" />
-    <style>
-        .post > p {
-            display: inline;
-        }
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <style type="text/tailwindcss">
         .post {
-            margin-left: -16px;
+            @apply px-[7px] py-[10px] list-none flex flex-row gap-2 align-middle
         }
-        {{ range $k, $v := .Sites -}}
-            li.site-{{ $k }} {
-                list-style: none;
-                padding: 10px 30px;
-                background-image: url({{$v.IconUrl}});
-                background-repeat: no-repeat;
-                background-position: left center;
-                background-size: 16px;
-            }
-        {{ end -}}
+        p {
+            @apply my-[16px]
+        }
+        .section__title {
+            @apply font-semibold text-xl pt-[20px]
+        }
+        a {
+            @apply text-blue-600
+        }
     </style>
 </head>
 <body>
-   <main>
-    <article>
-        <h1>planet eniehack</h1>
-        <p>
-            <a href="https://planet.debian.org/">Planet Debian</a>、<a href="https://planet.osm.org/">Planet OSM</a>や<a href="https://kanzaki.com/info/planet">Planet masaka</a>のように、僕個人の最新情報を1つのページにまとめたものです。
-        </p>
-        <p>
-            データソースは以下の通りです:
-            <ul>
-                {{ range $k, $v := .Sites}}
-                    <li><a href="{{- $v.Url -}}"><img src="{{- $v.IconUrl -}}" width="16" height="16"/>{{$v.Title}}</a></li>
-                {{ end }}
-            </ul>
-        </p>
-        {{ range $i, $k := .Keys -}}
-        <section id="{{$k}}">
-            <h2><time datetime="{{- $k -}}">{{- $k -}}</time></h2>
-            <ul>
-            {{ range $j, $post := (index $.Posts $k) -}}
-                <li class="post site-{{ $post.Src -}}" id="{{- $post.Id -}}">
-                    <p>
-                        {{- $post.Content -}}
-                    </p>
-                    (<a href="{{- $post.Url -}}"><time datetime="{{- $post.ParsedDate.Format "2006-01-02T15:04:05Z07:00"  -}}">{{- $post.ParsedDate.Format "15:04" -}}</time></a>)
-                </li>
-            {{ end -}}
-            </ul>
-        </section>
-        {{ end -}}
-    </article>
-   </main> 
-   <footer>
-        <p><a href="https://github.com/eniehack/planet-someone">planet-someone</a>(revision: {{ $.Meta.Version }})</p>
-   </footer>
+    <div class="@container">
+        <main class="mx-auto w-full @xl:max-w-[540px] @3xl:max-w-[720px] @5xl:max-w-[960px] @7xl:max-w-[1140px]">
+            <article>
+                <h1 class="text-5xl font-black my-[21px]">planet eniehack</h1>
+                <p>
+                    <a href="https://planet.debian.org/">Planet Debian</a>や<a href="https://kanzaki.com/info/planet">Planet masaka</a>のように、僕個人の最新情報を1つのページにまとめたものです。
+                </p>
+                <p>
+                    データソースは以下の通りです:
+                    <ul>
+                        {{ range $k, $v := .Sites}}
+                            <li>
+                                <img class="inline" src="{{- $v.IconUrl -}}" width="16" height="16"/>
+                                <a class="" href="{{- $v.Url -}}">
+                                    {{$v.Title}}
+                                </a>
+                            </li>
+                        {{ end }}
+                    </ul>
+                </p>
+                {{ range $i, $k := .Keys -}}
+                <section id="{{$k}}">
+                    <h2 class="section__title"><time datetime="{{- $k -}}">{{- $k -}}</time></h2>
+                    <ul>
+                    {{ range $j, $post := (index $.Posts $k) -}}
+                        {{ $site := index $.Sites $post.Src }}
+                        <li class="post" id="{{- $post.Id -}}">
+                            <div>
+                                <div class="size-6">
+                                    <img src="{{- $site.IconUrl -}}" />
+                                </div>
+                            </div>
+                            <div>
+                                <p class="inline">
+                                    {{- $post.Content -}}
+                                </p>
+                                (<a rel="nofollow" href="{{- $post.Url -}}"><time datetime="{{- $post.ParsedDate.Format "2006-01-02T15:04:05Z07:00"  -}}">{{- $post.ParsedDate.Format "15:04" -}}</time></a>)
+                            </div>
+                        </li>
+                    {{ end -}}
+                    </ul>
+                </section>
+                {{ end -}}
+            </article>
+        </main> 
+        <footer class="mx-auto">
+             <p><a href="https://github.com/eniehack/planet-someone">planet-someone</a>(revision: {{ $.Meta.Version }})</p>
+        </footer>
+    </div>
 </body>

--- a/template/index.html
+++ b/template/index.html
@@ -65,6 +65,6 @@
     </article>
    </main> 
    <footer>
-        <a href="https://github.com/eniehack/planet-someone">ソースコード（GitHub）</a>
+        <p><a href="https://github.com/eniehack/planet-someone">planet-someone</a>(revision: {{ $.Meta.Version }})</p>
    </footer>
 </body>


### PR DESCRIPTION
- feat!(config): configのschemaをsiteごとに柔軟に設定できるように
- feat(template):  生成されるhtmlにtailwindを使うようにした
- feat(picker/mastodon): contentを整形するようした
- feat(picker/mastodon): boostも含めるようにした


cronで動かして動くようになったらmergeしよう